### PR TITLE
bump tekton-pipelines to version 0.14.2 and small fixes

### DIFF
--- a/charts/pipelines/Chart.yaml
+++ b/charts/pipelines/Chart.yaml
@@ -1,8 +1,8 @@
 name: pipelines
 icon: https://tekton.dev/images/tekton-horizontal-color.png
 apiVersion: v1
-version: 0.12.0
-appVersion: v0.12.1
+version: 0.14.2
+appVersion: v0.14.2
 home: https://github.com/tektoncd/pipeline
 keywords:
   - helm

--- a/charts/pipelines/Chart.yaml
+++ b/charts/pipelines/Chart.yaml
@@ -1,7 +1,7 @@
 name: pipelines
 icon: https://tekton.dev/images/tekton-horizontal-color.png
 apiVersion: v1
-version: 0.14.2
+version: 0.14.0
 appVersion: v0.14.2
 home: https://github.com/tektoncd/pipeline
 keywords:
@@ -13,5 +13,7 @@ keywords:
 maintainers:
   - name: eddycharly
     email: ceb@agriconomie.com
+  - name: bcollard
+    email: baptiste.collard@gmail.com
 description: |
   This chart bootstraps installation of [tekton pipeline](https://github.com/tektoncd/pipeline).

--- a/charts/pipelines/README.md
+++ b/charts/pipelines/README.md
@@ -82,7 +82,7 @@ helm uninstall my-pipeline --namespace tekton
 
 ## Version
 
-Current chart version is `0.12.0`
+Current chart version is `0.14.2`
 
 ## Chart Values
 

--- a/charts/pipelines/crds/clustertask.yaml
+++ b/charts/pipelines/crds/clustertask.yaml
@@ -23,10 +23,10 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
     - name: v1beta1
       served: true
-      storage: false
+      storage: true
   names:
     kind: ClusterTask
     plural: clustertasks
@@ -38,4 +38,9 @@ spec:
   # starts to increment
   subresources:
     status: {}
-  version: v1alpha1
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: tekton-pipelines

--- a/charts/pipelines/crds/pipeline.yaml
+++ b/charts/pipelines/crds/pipeline.yaml
@@ -23,10 +23,10 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
     - name: v1beta1
       served: true
-      storage: false
+      storage: true
   names:
     kind: Pipeline
     plural: pipelines
@@ -38,4 +38,9 @@ spec:
   # starts to increment
   subresources:
     status: {}
-  version: v1alpha1
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: tekton-pipelines

--- a/charts/pipelines/crds/pipelinerun.yaml
+++ b/charts/pipelines/crds/pipelinerun.yaml
@@ -23,10 +23,10 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
     - name: v1beta1
       served: true
-      storage: false
+      storage: true
   names:
     kind: PipelineRun
     plural: pipelineruns
@@ -54,4 +54,9 @@ spec:
   # starts to increment
   subresources:
     status: {}
-  version: v1alpha1
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: tekton-pipelines

--- a/charts/pipelines/crds/task.yaml
+++ b/charts/pipelines/crds/task.yaml
@@ -23,10 +23,10 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
     - name: v1beta1
       served: true
-      storage: false
+      storage: true
   names:
     kind: Task
     plural: tasks
@@ -38,4 +38,9 @@ spec:
   # starts to increment
   subresources:
     status: {}
-  version: v1alpha1
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: tekton-pipelines

--- a/charts/pipelines/crds/taskrun.yaml
+++ b/charts/pipelines/crds/taskrun.yaml
@@ -23,10 +23,10 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
     - name: v1beta1
       served: true
-      storage: false
+      storage: true
   names:
     kind: TaskRun
     plural: taskruns
@@ -54,4 +54,9 @@ spec:
   # starts to increment
   subresources:
     status: {}
-  version: v1alpha1
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: tekton-pipelines

--- a/charts/pipelines/templates/webhook_deployment.yaml
+++ b/charts/pipelines/templates/webhook_deployment.yaml
@@ -72,6 +72,8 @@ spec:
               value: {{ template "pipelines.fullname" . }}
             - name: METRICS_DOMAIN
               value: tekton.dev/pipeline
+            - name: CONFIG_FEATURE_FLAGS_NAME
+              value: {{ template "pipelines.fullname" . }}-feature-flags
           securityContext:
             allowPrivilegeEscalation: false
           {{- with .Values.webhook.resources }}

--- a/charts/pipelines/templates/webhook_role.yaml
+++ b/charts/pipelines/templates/webhook_role.yaml
@@ -43,5 +43,5 @@ rules:
       - get
       - update
     resourceNames:
-      - webhook-certs
+      - {{ template "pipelines.fullname" . }}
 {{- end }}

--- a/charts/pipelines/values.yaml
+++ b/charts/pipelines/values.yaml
@@ -25,10 +25,23 @@ config:
   # config.artifactBucket -- Configuration for artifact bucket (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
   # @default -- See [values.yaml](./values.yaml)
   artifactBucket: {}
+  #    # location of the gcs bucket to be used for artifact storage
+  #    location: "gs://bucket-name"
+  #    # name of the secret that will contain the credentials for the service account
+  #    # with access to the bucket
+  #    bucket.service.account.secret.name:
+  #    # The key in the secret with the required service account json
+  #    bucket.service.account.secret.key:
 
   # config.artifactPvc -- Configuration for artifact pvc (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
   # @default -- See [values.yaml](./values.yaml)
   artifactPvc: {}
+  #   # size of the PVC volume
+  #   size: 5Gi
+  #
+  #   # storage class of the PVC volume
+  #   storageClassName: storage-class-name
+
 
   # config.defaults -- Configuration for default values (see https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
   # @default -- See [values.yaml](./values.yaml)
@@ -68,9 +81,25 @@ config:
       # is specified, the default pod template is ignored.
       # default-pod-template:
 
+      # default-cloud-events-sink contains the default CloudEvents sink to be
+      # used for TaskRun and PipelineRun, when no sink is specified.
+      # Note that right now it is still not possible to set a PipelineRun or
+      # TaskRun specific sink, so the default is the only option available.
+      # If no sink is specified, no CloudEvent is generated
+      # default-cloud-events-sink:
+
   # config.featureFlags -- Configuration for feature flags
   # @default -- See [values.yaml](./values.yaml)
   featureFlags:
+    # Setting this flag to "true" will prevent Tekton to create an
+    # Affinity Assistant for every TaskRun sharing a PVC workspace
+    #
+    # The default behaviour is for Tekton to create Affinity Assistants
+    #
+    # See more in the workspace documentation about Affinity Assistant
+    # https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md#affinity-assistant-and-specifying-workspace-order-in-a-pipeline
+    # or https://github.com/tektoncd/pipeline/pull/2630 for more info.
+    disable-affinity-assistant: "false"
     # Setting this flag to "true" will prevent Tekton overriding your
     # Task container's $HOME environment variable.
     #
@@ -91,6 +120,14 @@ config:
     # See https://github.com/tektoncd/pipeline/issues/1836 for more
     # info.
     disable-working-directory-overwrite: "false"
+    # This option should be set to false when Pipelines is running in a
+    # cluster that does not use injected sidecars such as Istio. Setting
+    # it to false should decrease the time it takes for a TaskRun to start
+    # running. For clusters that use injected sidecars, setting this
+    # option to false can lead to unexpected behavior.
+    #
+    # See https://github.com/tektoncd/pipeline/issues/2080 for more info.
+    running-in-environment-with-injected-sidecars: "true"
 
   # config.leaderElection -- Configuration for leader election
   # @default -- See [values.yaml](./values.yaml)
@@ -206,25 +243,27 @@ controller:
   # @default -- See [values.yaml](./values.yaml)
   args:
     - -kubeconfig-writer-image
-    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.12.1
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.14.2
     - -creds-image
-    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.12.1
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.14.2
     - -git-image
-    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.12.1
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.14.2
     - -nop-image
     - tianon/true@sha256:009cce421096698832595ce039aa13fa44327d96beedb84282a69d3dbcf5a81b
     - -shell-image
-    - busybox@sha256:a2490cec4484ee6c1068ba3a05f89934010c85242f736280b35343483b2264b6
+    - gcr.io/distroless/base@sha256:f79e093f9ba639c957ee857b1ad57ae5046c328998bf8f72b30081db4d8edbe4
     - -gsutil-image
-    - google/cloud-sdk@sha256:6e8676464c7581b2dc824956b112a61c95e4144642bec035e6db38e3384cae2e
+    - google/cloud-sdk@sha256:37654ada9b7afbc32828b537030e85de672a9dd468ac5c92a36da1e203a98def
     - -entrypoint-image
-    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.12.1
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.14.2
     - -imagedigest-exporter-image
-    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.12.1
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.14.2
     - -pr-image
-    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.12.1
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.14.2
     - -build-gcs-fetcher-image
-    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/vendor/github.com/googlecloudplatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher:v0.12.1
+    - gcr.io/tekton-releases/github.com/tektoncd/pipeline/vendor/github.com/googlecloudplatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher:v0.14.2
+    - -affinity-assistant-image
+    - nginx@sha256:c870bf53de0357813af37b9500cb1c2ff9fb4c00120d5fe1d75c21591293c34d
 
   service:
     # controller.service.type -- Controller service type


### PR DESCRIPTION
- merge CRDs with definitions v0.14.2 from "upstream" [release.yaml](https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.14.2/release.yaml)
- same for values.yaml: fix args for the tekton controller and values in different configmaps
- fix feature-flags configmap name on the webhook deployment (add env var)
- fix secret name in the webhook role

